### PR TITLE
fix: 投稿編集時のレイアウトのずれを修正#66

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -353,6 +353,7 @@ p {
     padding: 0px 0px;
     background: 0 0;
     position: relative;
+    border: 1px solid #ccc;
 }
 
 
@@ -366,17 +367,23 @@ p {
     transform: translate(-50%, -50%);
 }
 
+.uk-form-custom input[type=file] {
+    font-size: 500px;
+    overflow: hidden;
 
+}
 
 .preview {
     position: absolute;
+    /* 現在:, 変更:, クリア表示を隠す  */
+    top: 0px;
     z-index: 100;
     pointer-events: none;
 }
 
 .preview img#image-preview {
-    width: 556px;
-    height: 414px;
+    width: 558px;
+    height: 418px;
 }
 
 .preview img#icon_image-preview {
@@ -401,7 +408,7 @@ p {
     max-width: 100%;
     vertical-align: middle;
     height: 420px;
-    border: 2px dashed gray;
+    /* border: 2px dashed gray; */
 }
 
 .uk-form-custom:hover {
@@ -518,17 +525,17 @@ a.fixed-btn:hover {
     margin-right: 5px;
 }
 
-#header_post_icon{
+#header_post_icon {
     color: #333333;
     margin-right: 5px;
 }
 
-#mypage_icon{
+#mypage_icon {
     color: #333333;
     margin-right: 5px;
 }
 
-#logout_icon{
+#logout_icon {
     margin-right: 5px;
 }
 
@@ -551,7 +558,7 @@ a.fixed-btn:hover {
     border-radius: 5px;
 }
 
-.dropdown{
+.dropdown {
     text-align: center;
     width: 140px;
     margin: 10px auto;

--- a/templates/sns/post_form.html
+++ b/templates/sns/post_form.html
@@ -14,7 +14,7 @@
                                 <div class="uk-width-1-2">
                                     <div uk-form-custom>
                                         <div class="uk-placeholder uk-text-center">
-                                            {{ form.image }}
+                                            {{ form.image|remove_attr:"label" }}
                                             <div class="preview">
                                                 {{ form.media }}
                                                 <img id="image-preview">


### PR DESCRIPTION
投稿編集やユーザーアイコンを編集する際にアップロード欄に「現在：」「変更：」「□クリア」などというテキストが表示され、画像がずれるバグを修正した。
```
.preview {
    position: absolute;
    /* 現在:, 変更:, クリア表示を隠す  */
    top: 0px;
    z-index: 100;
    pointer-events: none;
}
```